### PR TITLE
List only files under the directories

### DIFF
--- a/ruby21x.spec
+++ b/ruby21x.spec
@@ -57,10 +57,10 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-, root, root)
-%{_bindir}
-%{_includedir}
-%{_datadir}
-%{_libdir}
+%{_bindir}/*
+%{_includedir}/*
+%{_datadir}/*
+%{_libdir}/*
 
 %changelog
 * Fri May  9 2014 Masahito Yoshida <masahito@axsh.net> - 2.1.2


### PR DESCRIPTION
According to Fedora's RPM packaging document [1], "do not list %{_bindir}".
Add "/*" to cover only the files under the directories, not including the directories themselves.

1: https://fedoraproject.org/wiki/How_to_create_an_RPM_package#.25files_section
